### PR TITLE
LoggedCmd fix

### DIFF
--- a/scylla/tests/ccm-integration/ccm/cluster.rs
+++ b/scylla/tests/ccm-integration/ccm/cluster.rs
@@ -61,11 +61,6 @@ impl ClusterOptions {
     fn cluster_dir(&self) -> String {
         format!("{}/{}/{}", self.root_dir, self.name, self.name)
     }
-
-    /// A file to store all ccm logs
-    fn ccm_log_file(&self) -> String {
-        format!("{}/{}/ccm.log", self.root_dir, self.name)
-    }
 }
 
 impl Default for ClusterOptions {

--- a/scylla/tests/ccm-integration/ccm/cluster.rs
+++ b/scylla/tests/ccm-integration/ccm/cluster.rs
@@ -459,9 +459,6 @@ impl Cluster {
                 DBType::Scylla => {
                     args.push("--scylla".to_string());
                 }
-                DBType::Datastax => {
-                    args.push("--dse".to_string());
-                }
                 DBType::Cassandra => {}
             }
             node.logged_cmd

--- a/scylla/tests/ccm-integration/ccm/cluster.rs
+++ b/scylla/tests/ccm-integration/ccm/cluster.rs
@@ -516,9 +516,7 @@ impl Cluster {
             },
         }
 
-        let lcmd = LoggedCmd::new(opts.ccm_log_file())
-            .await
-            .with_context(|| format!("failed to create command logger {}", opts.ccm_log_file()))?;
+        let lcmd = LoggedCmd::new().await;
 
         let mut cluster = Cluster {
             destroyed: false,

--- a/scylla/tests/ccm-integration/ccm/cluster.rs
+++ b/scylla/tests/ccm-integration/ccm/cluster.rs
@@ -240,7 +240,7 @@ impl Node {
         }
 
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::Env(self.get_ccm_env()))
+            .run_command("ccm", &args, RunOptions::new().with_env(self.get_ccm_env()))
             .await?;
         self.set_status(NodeStatus::Started);
         Ok(())
@@ -260,7 +260,7 @@ impl Node {
             }
         }
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::Env(self.get_ccm_env()))
+            .run_command("ccm", &args, RunOptions::new().with_env(self.get_ccm_env()))
             .await?;
         self.set_status(NodeStatus::Stopped);
         Ok(())
@@ -277,7 +277,7 @@ impl Node {
             self.opts.config_dir.clone(),
         ];
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::None)
+            .run_command("ccm", &args, RunOptions::new())
             .await?;
         self.set_status(NodeStatus::Deleted);
         Ok(())
@@ -306,7 +306,7 @@ impl Node {
 
         args.extend(additional);
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::None)
+            .run_command("ccm", &args, RunOptions::new())
             .await?;
         Ok(())
     }
@@ -462,7 +462,7 @@ impl Cluster {
                 DBType::Cassandra => {}
             }
             node.logged_cmd
-                .run_command("ccm", &args, RunOptions::Env(node.get_ccm_env()))
+                .run_command("ccm", &args, RunOptions::new().with_env(node.get_ccm_env()))
                 .await
                 .expect("failed to add node");
         }
@@ -563,7 +563,7 @@ impl Cluster {
             args.push("--scylla".to_string());
         }
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::None)
+            .run_command("ccm", &args, RunOptions::new())
             .await?;
         let nodes_str = self
             .opts
@@ -583,7 +583,7 @@ impl Cluster {
             config_dir.clone(),
         ];
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::None)
+            .run_command("ccm", &args, RunOptions::new())
             .await?;
         Ok(())
     }
@@ -617,7 +617,7 @@ impl Cluster {
         }
 
         self.logged_cmd
-            .run_command("ccm", &args, RunOptions::Env(self.get_ccm_env()))
+            .run_command("ccm", &args, RunOptions::new().with_env(self.get_ccm_env()))
             .await?;
         for node in self.nodes.iter() {
             let mut node = node.write().await;
@@ -641,7 +641,7 @@ impl Cluster {
                     "--config-dir",
                     &self.opts.config_dir(),
                 ],
-                RunOptions::None,
+                RunOptions::new(),
             )
             .await
         {
@@ -691,7 +691,7 @@ impl Cluster {
                     "--config-dir",
                     &self.opts.config_dir(),
                 ],
-                RunOptions::None,
+                RunOptions::new(),
             )
             .await
         {

--- a/scylla/tests/ccm-integration/ccm/logged_cmd.rs
+++ b/scylla/tests/ccm-integration/ccm/logged_cmd.rs
@@ -8,9 +8,8 @@ use std::sync::atomic::AtomicI32;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
-// A simple abstraction to run commands, log command, exit code its stderr, stdout to a file
-//  and optionally to own stderr/stdout
-// It should allow to run multiple commands in parallel
+/// A simple abstraction to run commands, and emit logs during its execution.
+/// It should allow to run multiple commands in parallel.
 pub(crate) struct LoggedCmd {
     run_id: AtomicI32,
 }

--- a/scylla/tests/ccm-integration/ccm/logged_cmd.rs
+++ b/scylla/tests/ccm-integration/ccm/logged_cmd.rs
@@ -16,6 +16,7 @@ use tokio::task;
 //  and optionally to own stderr/stdout
 // It should allow to run multiple commands in parallel
 pub(crate) struct LoggedCmd {
+    file: Arc<Mutex<File>>,
     run_id: AtomicI32,
 }
 

--- a/scylla/tests/ccm-integration/test_example.rs
+++ b/scylla/tests/ccm-integration/test_example.rs
@@ -1,5 +1,5 @@
 use crate::ccm::cluster::{Cluster, ClusterOptions};
-use crate::ccm::CLUSTER_VERSION;
+use crate::ccm::{cluster_1_node, run_ccm_test, CLUSTER_VERSION};
 use anyhow::{Context, Error};
 
 use scylla::client::session::Session;
@@ -16,8 +16,6 @@ async fn cluster_1_options() -> ClusterOptions {
         ..ClusterOptions::default()
     }
 }
-
-
 
 async fn get_session(cluster: &Cluster) -> Session {
     let endpoints = cluster.nodes.get_contact_endpoints().await;


### PR DESCRIPTION
 This PR removes logic responsible to writing the logs to the file by `LoggedCmd`. Instead, we will simply emit the logs using tracing crate.

Some context information (e.g. command start, finish, env variables) is logged at INFO level. The stdout and stderr of supervised command is logged at DEBUG level.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
