### PR TITLE
ccm/cluster: convert NodeStopOption and NodeStartOption to structs

### DIFF
--- a/scylla/tests/ccm_integration/ccm/cluster.rs
+++ b/scylla/tests/ccm_integration/ccm/cluster.rs
@@ -159,6 +159,10 @@ impl Default for NodeStartOptions {
 }
 
 impl NodeStartOptions {
+    const NO_WAIT: &str = "--no-wait";
+    const WAIT_OTHER_NOTICE: &str = "--wait-other-notice";
+    const WAIT_FOR_BINARY_PROTO: &str = "--wait-for-binary-proto";
+
     /// Creates the default start options. Enables following ccm options:
     /// - `--wait-other-notice`
     /// - `--wait-for-binary-proto`
@@ -202,6 +206,9 @@ pub(crate) struct NodeStopOptions {
 }
 
 impl NodeStopOptions {
+    const NO_WAIT: &str = "--no-wait";
+    const NOT_GENTLY: &str = "--not-gently";
+
     /// Create a new `NodeStopOptions` with default values.
     /// All ccm options are disabled by default.
     #[allow(dead_code)]
@@ -309,13 +316,13 @@ impl Node {
             wait_for_binary_proto,
         } = opts.unwrap_or_default();
         if no_wait {
-            args.push("--no-wait".to_string());
+            args.push(NodeStartOptions::NO_WAIT.to_string());
         }
         if wait_other_notice {
-            args.push("--wait-other-notice".to_string());
+            args.push(NodeStartOptions::WAIT_OTHER_NOTICE.to_string());
         }
         if wait_for_binary_proto {
-            args.push("--wait-for-binary-proto".to_string());
+            args.push(NodeStartOptions::WAIT_FOR_BINARY_PROTO.to_string());
         }
 
         self.logged_cmd
@@ -338,10 +345,10 @@ impl Node {
             not_gently,
         } = opts;
         if no_wait {
-            args.push("--no-wait".to_string());
+            args.push(NodeStopOptions::NO_WAIT.to_string());
         }
         if not_gently {
-            args.push("--not-gently".to_string());
+            args.push(NodeStopOptions::NOT_GENTLY.to_string());
         }
 
         self.logged_cmd
@@ -695,13 +702,13 @@ impl Cluster {
             wait_for_binary_proto,
         } = opts.unwrap_or_default();
         if no_wait {
-            args.push("--no-wait".to_string());
+            args.push(NodeStartOptions::NO_WAIT.to_string());
         }
         if wait_other_notice {
-            args.push("--wait-other-notice".to_string());
+            args.push(NodeStartOptions::WAIT_OTHER_NOTICE.to_string());
         }
         if wait_for_binary_proto {
-            args.push("--wait-for-binary-proto".to_string());
+            args.push(NodeStartOptions::WAIT_FOR_BINARY_PROTO.to_string());
         }
 
         self.logged_cmd


### PR DESCRIPTION
Converted these two types to structs. Added some constructor methods and documented them.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
