### PR TITLE
ccm/cluster: fix NodeStopOptions builder methods

### DIFF
--- a/scylla/tests/ccm_integration/ccm/cluster.rs
+++ b/scylla/tests/ccm_integration/ccm/cluster.rs
@@ -221,14 +221,14 @@ impl NodeStopOptions {
 
     /// Enables or disables the `--no-wait` cmm option.
     #[allow(dead_code)]
-    pub(crate) fn no_wait(&mut self, no_wait: bool) -> &mut Self {
+    pub(crate) fn no_wait(mut self, no_wait: bool) -> Self {
         self.no_wait = no_wait;
         self
     }
 
     /// Enables or disables the `--not-gently` ccm option.
     #[allow(dead_code)]
-    pub(crate) fn not_gently(&mut self, not_gently: bool) -> &mut Self {
+    pub(crate) fn not_gently(mut self, not_gently: bool) -> Self {
         self.not_gently = not_gently;
         self
     }


### PR DESCRIPTION
So they are consistent with NodeStartOptions, RunOptions and SessionBuilder.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [ ] I have split my patch into logically separate commits.
- [ ] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [ ] All commits compile, pass static checks and pass test.
- [ ] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
